### PR TITLE
Allow the setting of the default Trello list card position

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 2. Copy your preferred List ID
 3. Paste it in plugin settings under "Default List ID"
 
-### 4. Available Commands
+### 4. Set Default Card Position
+1. Go to Plugin Settings > logseq-trello-plugin
+2. Set the default position for newly created Trello cards
+  - Valid values are `top`, `bottom` (default) or an absolute numeric position
+
+### 5. Available Commands
 - `/Send Block to Trello`: Creates a new card from your current block
 - `/Send Page to Trello`: Creates a new card from your current page (can trigger anywhere within the page)
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### 5. Working with Cards
+### 6. Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/index.js
+++ b/index.js
@@ -20,6 +20,13 @@ const settings = [
     title: "Default List ID",
     description: "Use /Trello Get Lists to find your list ID, then paste it here",
     default: ""
+  },
+  {
+    key: "defaultCardPos",
+    type: "string",
+    title: "Default Card Position",
+    description: "The default position in Trello list for new cards.  Specify either top, bottom or an absolute numeric position",
+    default: "bottom" // defaulting to bottom doesn't change existing behaviour
   }
 ];
 
@@ -71,7 +78,7 @@ async function checkExistingCard(token, listId, name) {
   return cards.find(card => card.name === name);
 }
 
-async function createTrelloCard(token, listId, name, desc = '') {
+async function createTrelloCard(token, listId, name, position, desc = '') {
   // First check if card already exists
   const existingCard = await checkExistingCard(token, listId, name);
   if (existingCard) {
@@ -108,7 +115,8 @@ async function createTrelloCard(token, listId, name, desc = '') {
       body: JSON.stringify({
         name,
         idList: listId,
-        desc
+        desc: desc,
+        pos: position
       })
     }
   );
@@ -304,6 +312,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
+    const position = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -316,7 +325,7 @@ function main() {
     }
 
     try {
-      const card = await createTrelloCard(token, listId, block.content);
+      const card = await createTrelloCard(token, listId, position, block.content);
       logseq.App.showMsg('Trello card created successfully!');
       
       // Add the card URL as a property to the block
@@ -336,6 +345,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
+    const position = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -362,7 +372,7 @@ function main() {
         .join('\n');
 
       // Create card with page title and content
-      const card = await createTrelloCard(token, listId, page.name, description);
+      const card = await createTrelloCard(token, listId, page.name, position, description);
       logseq.App.showMsg('Trello card created from page successfully!');
       
       // Add the card URL as a page property

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ async function checkExistingCard(token, listId, name) {
   return cards.find(card => card.name === name);
 }
 
-async function createTrelloCard(token, listId, name, position, desc = '') {
+async function createTrelloCard(token, listId, name, cardPosition, desc = '') {
   // First check if card already exists
   const existingCard = await checkExistingCard(token, listId, name);
   if (existingCard) {
@@ -116,7 +116,7 @@ async function createTrelloCard(token, listId, name, position, desc = '') {
         name,
         idList: listId,
         desc: desc,
-        pos: position
+        pos: cardPosition
       })
     }
   );
@@ -312,7 +312,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
-    const position = logseq.settings?.defaultCardPos;
+    const cardPosition = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -325,7 +325,7 @@ function main() {
     }
 
     try {
-      const card = await createTrelloCard(token, listId, position, block.content);
+      const card = await createTrelloCard(token, listId, block.content, cardPosition);
       logseq.App.showMsg('Trello card created successfully!');
       
       // Add the card URL as a property to the block
@@ -345,7 +345,7 @@ function main() {
     // Get settings
     const token = logseq.settings?.trelloToken;
     const listId = logseq.settings?.defaultListId;
-    const position = logseq.settings?.defaultCardPos;
+    const cardPosition = logseq.settings?.defaultCardPos;
 
     if (!token) {
       logseq.App.showMsg('Please configure your Trello token in plugin settings!', 'warning');
@@ -372,7 +372,7 @@ function main() {
         .join('\n');
 
       // Create card with page title and content
-      const card = await createTrelloCard(token, listId, page.name, position, description);
+      const card = await createTrelloCard(token, listId, page.name, cardPosition, description);
       logseq.App.showMsg('Trello card created from page successfully!');
       
       // Add the card URL as a page property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-trello-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "jarodise",
   "main": "index.html",
   "description": "📋 Trello integration for LogSeq",


### PR DESCRIPTION
- When creating a new card in an existing Trello list, allow setting of the default card position.  
- Default is to create the card at the bottom of the list.  
- This new setting **defaultCardPos** accepts values of **bottom**, **top** or an absolute numeric card position.