### PR TITLE
Add the ability to link the block/page with a short Trello card URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ This plugin provides seamless integration between Logseq and Trello, allowing yo
 2. Set the default position for newly created Trello cards
   - Valid values are `top`, `bottom` (default) or an absolute numeric position
 
-### 5. Available Commands
+### 5. Use short or long URL
+1. Go to Plugin Settings > logseq-trello-plugin
+2. Setup to use either the short or long URL when adding the URL link to the block/page after creating a Trello card
+
+### 6. Available Commands
 - `/Send Block to Trello`: Creates a new card from your current block
 - `/Send Page to Trello`: Creates a new card from your current page (can trigger anywhere within the page)
 - `/Trello Get Lists`: Shows all your Trello boards and lists
 - `/Trello Pull Cards`: Imports all cards from your default list
 
-### 6. Working with Cards
+### . Working with Cards
 1. **Creating Cards**:
    - Select a block or page you want to send to Trello
    - Use `/Send Block to Trello` or `/Send Page to Trello`

--- a/index.js
+++ b/index.js
@@ -27,6 +27,13 @@ const settings = [
     title: "Default Card Position",
     description: "The default position in Trello list for new cards.  Specify either top, bottom or an absolute numeric position",
     default: "bottom" // defaulting to bottom doesn't change existing behaviour
+  },
+  {
+    key: "shortUrl",
+    type: "boolean",
+    title: "Use short or long Trello card URL",
+    description: "Use the short URL in block/page content after creating a Trello card",
+    default: false // defaulting to false doesn't change existing behaviour
   }
 ];
 
@@ -327,11 +334,16 @@ function main() {
     try {
       const card = await createTrelloCard(token, listId, block.content, cardPosition);
       logseq.App.showMsg('Trello card created successfully!');
-      
+      let url = card.url; // default to long
+
+      if(logseq.settings?.shortUrl) {
+        url = card.shortUrl;
+      }
+
       // Add the card URL as a property to the block
       await logseq.Editor.updateBlock(
         block.uuid,
-        `${block.content}\ntrello-card:: ${card.url}`
+        `${block.content}\ntrello-card:: ${url}`
       );
 
     } catch (error) {
@@ -374,12 +386,17 @@ function main() {
       // Create card with page title and content
       const card = await createTrelloCard(token, listId, page.name, cardPosition, description);
       logseq.App.showMsg('Trello card created from page successfully!');
-      
+      let url = card.url; // default to long
+
+      if(logseq.settings?.shortUrl) {
+        url = card.shortUrl;
+      }
+
       // Add the card URL as a page property
       await logseq.Editor.upsertBlockProperty(
         page.uuid,
         'trello-card',
-        card.url
+        url
       );
 
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-trello-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "jarodise",
   "main": "index.html",
   "description": "📋 Trello integration for LogSeq",


### PR DESCRIPTION
When adding the content to the block/page after creating a Trello card, allow the ability to use the short URL returned by the Trello API.  This short URL does not take as much line space, and likely will not wrap o to the next line in the block/page